### PR TITLE
Ruby 3 compatibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,10 +39,10 @@ namespace :spec do
     t.rcov_opts = ['--exclude', "features,kernel,load-diff-lcs\.rb,instance_exec\.rb,lib/spec.rb,lib/spec/runner.rb,^spec/*,bin/spec,examples,/gems,/Library/Ruby,\.autotest,#{ENV['GEM_HOME']}"]
     t.rcov_opts << '--sort coverage --text-summary --aggregate coverage.data'
   end
-  
+
   desc "Run files listed in spec/spec_files.txt"
   Spec::Rake::SpecTask.new(:focus) do |t|
-    if File.exists?('spec/spec_files.txt')
+    if File.exist?('spec/spec_files.txt')
       t.spec_files = File.readlines('spec/spec_files.txt').collect{|f| f.chomp}
     end
   end

--- a/lib/spec/rake/spectask.rb
+++ b/lib/spec/rake/spectask.rb
@@ -146,7 +146,7 @@ module Spec
 
         lib_path = libs.join(File::PATH_SEPARATOR)
         actual_name = Hash === name ? name.keys.first : name
-        unless ::Rake.application.last_comment
+        unless ::Rake.application.last_description
           desc "Run specs" + (rcov ? " using RCov" : "")
         end
         task name do

--- a/lib/spec/rake/spectask.rb
+++ b/lib/spec/rake/spectask.rb
@@ -182,11 +182,11 @@ module Spec
 
         if rcov
           desc "Remove rcov products for #{actual_name}"
-          task paste("clobber_", actual_name) do
+          task :"clobber_#{actual_name}" do
             rm_r rcov_dir rescue nil
           end
 
-          clobber_task = paste("clobber_", actual_name)
+          clobber_task = :"clobber_#{actual_name}"
           task :clobber => [clobber_task]
 
           task actual_name => clobber_task

--- a/lib/spec/runner/options.rb
+++ b/lib/spec/runner/options.rb
@@ -52,7 +52,7 @@ module Spec
       )
       attr_reader :colour, :differ_class, :files, :examples, :example_groups
       attr_writer :drb_port
-      
+
       def initialize(error_stream, output_stream)
         @error_stream = error_stream
         @output_stream = output_stream
@@ -108,7 +108,7 @@ module Spec
         # project_path project:
         #   http://github.com/smtlaissezfaire/project_path
         Pathname(File.expand_path('.')).ascend do |path|
-          if File.exists?(File.join(path, "spec"))
+          if File.exist?(File.join(path, "spec"))
             return path
           end
         end
@@ -294,7 +294,7 @@ module Spec
       def drb_port
         @drb_port.to_i if defined?(@drb_port)
       end
-      
+
     protected
 
       def define_predicate_matchers


### PR DESCRIPTION
# Description
Replacing deprecated methods

- [Rake v11.0.0 and beyond removed Rake::TaskManager#last_comment](https://github.com/ruby/rake/commit/e76242ce7ef94568399a50b69bda4b723dab7c75)
- [Rake v11.0.0 and beyond removed Rake::TaskLib#paste](https://github.com/ruby/rake/commit/b5c1a696b410f422c38b2b07296031d9682c9795)
- [File#exists? was removed in Ruby 3.2](https://rubyreferences.github.io/rubychanges/3.2.html#removals)
